### PR TITLE
Feature/147 populate backend

### DIFF
--- a/dump.json
+++ b/dump.json
@@ -1,0 +1,209 @@
+{
+    "Patient": [
+        {
+            "_id": "e99312b0-db90-4e49-bac5-763844e89398",
+            "name": "Eva Mar\u00eda",
+            "first_surname": "Corbacho",
+            "second_surname": "Osuna",
+            "alias": "emcoos",
+            "nid": "2951073N",
+            "birth_date": "1990-01-21T00:00:00",
+            "gender": "Woman",
+            "address": "Calle Albano Gonzalez 11\nSevilla, 23762",
+            "contact_phone": "+34 744 25 66 06",
+            "dossier_number": "AykaG-4887091",
+            "first_technician": "Mar\u00eda Vilaplana Colomer",
+            "observations": "Muestra signos de ansiedad, es necesario ajustar el tratamiento."
+        },
+        {
+            "_id": "2dde0b45-61e5-4368-b9bc-d9aac8e5eb53",
+            "name": "Cebri\u00e1n",
+            "first_surname": "Murcia",
+            "second_surname": "G\u00e1mez",
+            "alias": "cemug\u00e1",
+            "nid": "23659072F",
+            "birth_date": "1956-10-21T00:00:00",
+            "gender": "Woman",
+            "address": "Avenida Te\u00f3filo Calleja 172\nGuip\u00fazcoa, 00715",
+            "contact_phone": "+34 702 73 85 26",
+            "dossier_number": "sJEcX-5476048",
+            "first_technician": "Marianela del Arenas",
+            "observations": "Paciente muestra una actitud positiva hacia el tratamiento."
+        },
+        {
+            "_id": "54e809a6-5b33-4bc2-8ef7-98285f4bcbf0",
+            "name": "Xavier",
+            "first_surname": "Prats",
+            "second_surname": "Carretero",
+            "alias": "xaprca",
+            "nid": "54194274H",
+            "birth_date": "1970-05-22T00:00:00",
+            "gender": "Man",
+            "address": "Callej\u00f3n Manola Aramburu 59\nValladolid, 64319",
+            "contact_phone": "+34 733 98 52 25",
+            "dossier_number": "sOsuF-0909255",
+            "first_technician": "Mar\u00eda Carmen Rosa Dom\u00ednguez",
+            "observations": "Ha compartido experiencias personales en las sesiones, lo que contribuye a su proceso de recuperaci\u00f3n."
+        },
+        {
+            "_id": "ae2d1cd2-d048-47b9-b87c-872ba63a06ef",
+            "name": "Abel",
+            "first_surname": "Chico",
+            "second_surname": "Arranz",
+            "alias": "abchar",
+            "nid": "59309320W",
+            "birth_date": "1940-05-05T00:00:00",
+            "gender": "Man",
+            "address": "Callej\u00f3n de Mariana Exp\u00f3sito 9\nCuenca, 82129",
+            "contact_phone": "+34 688 966 444",
+            "dossier_number": "uvmTY-0644888",
+            "first_technician": "Rosa Mar\u00eda Cifuentes Aguado",
+            "observations": "Paciente muestra una actitud positiva hacia el tratamiento."
+        },
+        {
+            "_id": "b3a5713a-c8c4-47e5-934d-ad38e6628c8b",
+            "name": "Maricela",
+            "first_surname": "Vidal",
+            "second_surname": "Cort\u00e9s",
+            "alias": "mavico",
+            "nid": "88735048J",
+            "birth_date": "2018-09-04T00:00:00",
+            "gender": "Man",
+            "address": "Calle de Chita Requena 630 Puerta 2 \nSanta Cruz de Tenerife, 70393",
+            "contact_phone": "+34 826 19 73 78",
+            "dossier_number": "rqBWZ-0985603",
+            "first_technician": "Jose Francisco de Paula Santander",
+            "observations": "Se observa una notable mejora en el comportamiento y en la interacci\u00f3n con el grupo."
+        }
+    ],
+    "User": [
+        {
+            "_id": "679c787b-7b28-413e-bfce-53d04b59c21b",
+            "username": "root",
+            "password": "$2b$12$mIuh2biooN3X0F2IexgS0O42dIFpv0mXTbhH7ow8.twcpimC4XcWK",
+            "email": "root@root.com"
+        }
+    ],
+    "Intervention": [
+        {
+            "_id": "94a40c42-9c7a-4d38-887b-3a0f91b0082c",
+            "date": "2019-10-10T00:00:00",
+            "reason": "Consulta urgente",
+            "typology": "Consulta m\u00e9dica",
+            "observations": "El paciente acude a la sesi\u00f3n con actitud positiva, dispuesto a participar activamente.",
+            "technician": "Mar\u00eda Vilaplana Colomer",
+            "patient": {
+                "id": "e99312b0-db90-4e49-bac5-763844e89398",
+                "name": "Eva Mar\u00eda",
+                "first_surname": "Corbacho",
+                "second_surname": "Osuna",
+                "alias": "emcoos",
+                "nid": "2951073N",
+                "birth_date": "1990-01-21T00:00:00",
+                "gender": "Woman",
+                "address": "Calle Albano Gonzalez 11\nSevilla, 23762",
+                "contact_phone": "+34 744 25 66 06",
+                "dossier_number": "AykaG-4887091",
+                "first_technician": "Mar\u00eda Vilaplana Colomer",
+                "registration_date": "2024-03-21T00:00:00",
+                "observations": "Muestra signos de ansiedad, es necesario ajustar el tratamiento."
+            }
+        },
+        {
+            "_id": "fca46342-fa47-4cf2-a1ae-27c18c9a8d89",
+            "date": "2020-03-21T00:00:00",
+            "reason": "Seguimiento mensual",
+            "typology": "Consulta m\u00e9dica",
+            "observations": "Muestra inter\u00e9s en las terapias grupales, se siente m\u00e1s c\u00f3modo en las sesiones.",
+            "technician": "Marianela del Arenas",
+            "patient": {
+                "id": "2dde0b45-61e5-4368-b9bc-d9aac8e5eb53",
+                "name": "Cebri\u00e1n",
+                "first_surname": "Murcia",
+                "second_surname": "G\u00e1mez",
+                "alias": "cemug\u00e1",
+                "nid": "23659072F",
+                "birth_date": "1956-10-21T00:00:00",
+                "gender": "Woman",
+                "address": "Avenida Te\u00f3filo Calleja 172\nGuip\u00fazcoa, 00715",
+                "contact_phone": "+34 702 73 85 26",
+                "dossier_number": "sJEcX-5476048",
+                "first_technician": "Marianela del Arenas",
+                "registration_date": "2024-03-21T00:00:00",
+                "observations": "Paciente muestra una actitud positiva hacia el tratamiento."
+            }
+        },
+        {
+            "_id": "cd249649-3cde-4e89-a055-f84e4053cbc1",
+            "date": "2020-11-29T00:00:00",
+            "reason": "Primera visita",
+            "typology": "Consulta m\u00e9dica",
+            "observations": "El paciente refiere sentirse m\u00e1s animado y con ganas de seguir adelante con el tratamiento.",
+            "technician": "Mar\u00eda Carmen Rosa Dom\u00ednguez",
+            "patient": {
+                "id": "54e809a6-5b33-4bc2-8ef7-98285f4bcbf0",
+                "name": "Xavier",
+                "first_surname": "Prats",
+                "second_surname": "Carretero",
+                "alias": "xaprca",
+                "nid": "54194274H",
+                "birth_date": "1970-05-22T00:00:00",
+                "gender": "Man",
+                "address": "Callej\u00f3n Manola Aramburu 59\nValladolid, 64319",
+                "contact_phone": "+34 733 98 52 25",
+                "dossier_number": "sOsuF-0909255",
+                "first_technician": "Mar\u00eda Carmen Rosa Dom\u00ednguez",
+                "registration_date": "2024-03-21T00:00:00",
+                "observations": "Ha compartido experiencias personales en las sesiones, lo que contribuye a su proceso de recuperaci\u00f3n."
+            }
+        },
+        {
+            "_id": "79adac5c-32d2-4e6f-ad8f-e3bfdb75d279",
+            "date": "2020-08-15T00:00:00",
+            "reason": "Primera visita",
+            "typology": "Consulta m\u00e9dica",
+            "observations": "El paciente refiere sentirse m\u00e1s animado y con ganas de seguir adelante con el tratamiento.",
+            "technician": "Rosa Mar\u00eda Cifuentes Aguado",
+            "patient": {
+                "id": "ae2d1cd2-d048-47b9-b87c-872ba63a06ef",
+                "name": "Abel",
+                "first_surname": "Chico",
+                "second_surname": "Arranz",
+                "alias": "abchar",
+                "nid": "59309320W",
+                "birth_date": "1940-05-05T00:00:00",
+                "gender": "Man",
+                "address": "Callej\u00f3n de Mariana Exp\u00f3sito 9\nCuenca, 82129",
+                "contact_phone": "+34 688 966 444",
+                "dossier_number": "uvmTY-0644888",
+                "first_technician": "Rosa Mar\u00eda Cifuentes Aguado",
+                "registration_date": "2024-03-21T00:00:00",
+                "observations": "Paciente muestra una actitud positiva hacia el tratamiento."
+            }
+        },
+        {
+            "_id": "6592f7c1-5943-4c59-b36d-d21b9ba7c8f3",
+            "date": "2015-08-15T00:00:00",
+            "reason": "Primera visita",
+            "typology": "Consulta urgente",
+            "observations": "El paciente acude a la sesi\u00f3n con actitud positiva, dispuesto a participar activamente.",
+            "technician": "Jose Francisco de Paula Santander",
+            "patient": {
+                "id": "b3a5713a-c8c4-47e5-934d-ad38e6628c8b",
+                "name": "Maricela",
+                "first_surname": "Vidal",
+                "second_surname": "Cort\u00e9s",
+                "alias": "mavico",
+                "nid": "88735048J",
+                "birth_date": "2018-09-04T00:00:00",
+                "gender": "Man",
+                "address": "Calle de Chita Requena 630 Puerta 2 \nSanta Cruz de Tenerife, 70393",
+                "contact_phone": "+34 826 19 73 78",
+                "dossier_number": "rqBWZ-0985603",
+                "first_technician": "Jose Francisco de Paula Santander",
+                "registration_date": "2024-03-21T00:00:00",
+                "observations": "Se observa una notable mejora en el comportamiento y en la interacci\u00f3n con el grupo."
+            }
+        }
+    ]
+}

--- a/src/core/database/backup.py
+++ b/src/core/database/backup.py
@@ -1,0 +1,42 @@
+import datetime
+import uuid
+import json
+from typing import Dict, List, Any
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from src.core.config import settings
+
+
+class BackupEncoder(json.JSONEncoder):
+    def default(self, obj: Any):
+        if isinstance(obj, uuid.UUID):
+            return str(obj)
+        elif isinstance(obj, datetime.datetime):
+            return obj.isoformat()
+        return super().default(obj)
+
+
+async def get_database_session() -> AsyncIOMotorClient:
+    client = AsyncIOMotorClient(
+        str(settings.MONGO_DATABASE_URI),
+        uuidRepresentation='standard',
+    )
+    db = client.get_database(settings.MONGO_DB)
+    return db
+
+
+async def populate_from_json(db: AsyncIOMotorDatabase, data: Dict[str, List[Dict[str, Any]]]) -> None:
+    for collection, collection_data in data.items():
+        await db[collection].delete_many({})
+        if collection_data:
+            await db[collection].insert_many(collection_data)
+
+
+async def dump_to_json(db: AsyncIOMotorDatabase) -> Dict[str, Any]:
+    json_data = {}
+    collections = await db.list_collection_names()
+    for collection in collections:
+        documents = await db[collection].find().to_list(None)
+        json_data[collection] = documents
+    return json_data

--- a/src/data.py
+++ b/src/data.py
@@ -1,0 +1,55 @@
+import argparse
+import asyncio
+import json
+
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from src.core.database import backup
+
+
+async def populate_json_data(motor: AsyncIOMotorClient, route: str):
+    try:
+        with open(route, 'r', encoding='utf-8') as file:
+            data = json.load(file)
+            if not isinstance(data, dict) or not all(isinstance(value, list) for value in data.values()):
+                raise ValueError("Invalid JSON data format")
+            await backup.populate_from_json(motor, data)
+    except FileNotFoundError:
+        print(f"File not found: {route}")
+    except json.JSONDecodeError:
+        print(f"Invalid JSON format in file: {route}")
+    except ValueError as e:
+        print(f"Invalid JSON data format: {e}")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+
+async def dump_json_data(motor: AsyncIOMotorClient, route: str):
+    try:
+        data = await backup.dump_to_json(motor)
+        with open(route, 'w', encoding='utf-8') as file:
+            json.dump(data, file, indent=4, cls=backup.BackupEncoder)
+            print(f"Data dumped to file: {route}")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Dump or retrieve JSON data")
+    parser.add_argument("option", choices=[
+                        "dump", "populate"], help="Dump or retrieve JSON data")
+    parser.add_argument("route", help="File route")
+
+    args = parser.parse_args()
+
+    db = await backup.get_database_session()
+    client = db.client
+    if args.option == "dump":
+        await dump_json_data(db, args.route)
+    elif args.option == "populate":
+        await populate_json_data(db, args.route)
+
+    client.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Description
Added db dump and populate scripts and mock data for acat and global user

## Related Issue(s)
- #147 

## Checklist
- [x] I have read and followed the project's contributing guidelines.
- [x] I have tested the changes locally.
- [x] I have made corresponding changes to the documentation if necessary.
- [x] My code follows the project's code style guidelines.

## Reviewers
- @alejandromd 

## Notes 
To use the new implemented functionality, follow the next scheme:

### Dump data from db

`python -m src.data dump route_of_the_json_file_to_store_data`

### Populate db 

`python -m src.data populate route_of__the_json_file_with_mock_data`

> Note: the populate script will remove all the data stored in your db instance before storing the new data.